### PR TITLE
Allow escape \xN at end of string

### DIFF
--- a/pickle.c
+++ b/pickle.c
@@ -885,7 +885,7 @@ static int picolUnEscape(char *inout) {
 			case  ']': r[k] = ']';  break;
 			case  'e': r[k] = 27;   break;
 			case  'x': {
-				if (!inout[j + 1] || !inout[j + 2])
+				if (!inout[j + 1])
 					return -1;
 				const char v[3] = { inout[j + 1], inout[j + 2], 0 };
 				unsigned d = 0;
@@ -2029,8 +2029,9 @@ static int picolTestUnescape(void) {
 		{  "a\\[z\\[a",     "a[z[a",  5   },
 		{  "\\\\",          "\\",     1   },
 		{  "\\x30",         "0",      1   },
-		{  "\\xZ",          "N/A",    -1  },
+		{  "\\xZ",          "N/A",    -2  },
 		{  "\\xZZ",         "N/A",    -2  },
+		{  "\\x9",          "\x09",   1   },
 		{  "\\x9Z",         "\011Z",  2   },
 		{  "\\x300",        "00",     2   },
 		{  "\\x310",        "10",     2   },

--- a/unit.tcl
+++ b/unit.tcl
@@ -178,6 +178,9 @@ test 1 {string is alpha abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ}
 test 1 {string is ascii ""}
 test 0 {string is ascii "a\x80a"}
 test 0 {string is ascii "\x82"}
+test 1 {string is ascii "\x01"}
+test 1 {string is ascii "\x1 "}
+test 1 {string is ascii "\x1"}
 test 1 {string is ascii "aa"}
 test 1 {string is ascii "\x7f"}
 test 1 {string is xdigit ""}
@@ -216,6 +219,7 @@ test -1 {string first d bbbaca}
 test 0 {string ordinal ""}
 test 0 {string ordinal "\x00"}
 test 1 {string ordinal "\x01"}
+test 2 {string ordinal "\x2"}
 test 48 {string ordinal "0"}
 test 49 {string ordinal "1"}
 test 49 {string ordinal "1a"}


### PR DESCRIPTION
The first two commits makes the `\xN` more consistent: it allows `\xN` to appear at end of a string in the escape resolver.

The third commit relaxes link dependencies by not using `sscanf()`.