### PR TITLE
public pickle_set_result_empty

### DIFF
--- a/main.c
+++ b/main.c
@@ -69,7 +69,7 @@ static int pickleCommandPuts(pickle_t *i, const int argc, char **argv, void *pd)
 	const int r2 = fflush((FILE*)pd);
 	if (r1 < 0 || r2 < 0)
 		return pickle_set_result_error(i, "I/O error: %d/%d", r1, r2);
-	return PICKLE_OK;
+	return pickle_set_result_empty(i);
 }
 
 static int get_a_line(FILE *input, char **out) {

--- a/pickle.c
+++ b/pickle.c
@@ -1025,6 +1025,10 @@ int pickle_set_result(pickle_t *i, const char *fmt, ...) {
 	return picolForceResult(i, r, 0);
 }
 
+int pickle_set_result_empty(pickle_t *i) {
+	return picolSetResultEmpty(i);
+}
+
 int pickle_set_result_integer(pickle_t *i, const long result) {
 	assert(i);
 	assert(i->initialized);

--- a/pickle.h
+++ b/pickle.h
@@ -42,6 +42,7 @@ PICKLE_API int pickle_eval(pickle_t *i, const char *t);
 PICKLE_API int pickle_register_command(pickle_t *i, const char *name, pickle_command_func_t f, void *privdata);
 PICKLE_API int pickle_rename_command(pickle_t *i, const char *src, const char *dst); /* if 'dst' is "" then command is deleted */
 
+PICKLE_API int pickle_set_result_empty(pickle_t *i);
 PICKLE_API int pickle_set_result(pickle_t *i, const char *fmt, ...);
 PICKLE_API int pickle_set_result_string(pickle_t *i, const char *s);
 PICKLE_API int pickle_set_result_integer(pickle_t *i, long result);


### PR DESCRIPTION
Allows user commands to reset the result.
Similar to `Tcl_ResetResult()`: https://www.tcl.tk/man/tcl/TclLib/SetResult.htm

Example
```
$ cat /tmp/empty.tcl 
set a world
set res0 [puts "hello world"]
set res1 [puts "hello $a"]
set res2 [puts "hello [set a]"]
puts $res0
puts $res1
puts $res2
```

Before this commit:
```
$ ./pickle /tmp/empty.tcl
hello world
hello world
hello world


world
```

After this commit, which is also consistent with `tcl8.6`:
```
$ ./pickle /tmp/empty.tcl
hello world
hello world
hello world



```
