### PR TITLE
reset result before invoking a command

### DIFF
--- a/pickle.c
+++ b/pickle.c
@@ -1267,6 +1267,8 @@ static inline int picolDoCommand(pickle_t *i, int argc, char *argv[]) {
 	assert(i);
 	assert(argc >= 1);
 	assert(argv);
+	if (pickle_set_result_empty(i) != PICKLE_OK)
+		return PICKLE_ERROR;
 	struct pickle_command *c = picolGetCommand(i, argv[0]);
 	if (c == NULL) { 
 		if ((c = picolGetCommand(i, "unknown")) == NULL) 


### PR DESCRIPTION
This pull request sets the command result to a known clean state before invoking the command.

Consistent with Tcl 8.
According to [Practical Programming in Tcl and Tk](http://beedub.com/book/), chapter [C Programming and Tcl](http://beedub.com/book/3rd/Cprogint.pdf):
> `Tcl_ResetResult` is always called before a command procedure is invoked.
