### PR TITLE
fixed off-by-one in string allocation

### DIFF
--- a/pickle.c
+++ b/pickle.c
@@ -942,7 +942,7 @@ static char *picolVsprintf(pickle_t *i, const char *fmt, va_list ap) {
 			goto fail;
 		if (r < (int)h.length) /* Casting to 'int' is not ideal, but we have no choice */
 			break;
-		if (picolStackOrHeapAlloc(i, &h, r) != PICKLE_OK)
+		if (picolStackOrHeapAlloc(i, &h, r + 1) != PICKLE_OK)
 			goto fail;
 	}
 	if (!picolOnHeap(i, &h)) {


### PR DESCRIPTION
This script freezes `pickle`:
```
set v a
for {set i 0} {!= $i 256} {incr i} {
        set v "x$v"
        puts "i=$i, v=$v"
        catch {set $v} x
}
```

It freezes when the result string has a certain length (64).

The issue is related to the interpretation of the `snprintf()` return value. The returned number never includes the terminating `NUL`. So bump by `+ 1` to allocate enough.
