### PR TITLE
proc: replace old procedure

### DIFF
--- a/pickle.c
+++ b/pickle.c
@@ -2698,6 +2698,12 @@ static int picolCommandProc(pickle_t *i, const int argc, char **argv, void *pd) 
 	assert(!pd);
 	if (argc != 4)
 		return pickle_set_result_error_arity(i, 4, argc, argv);
+	pickle_command_t *np = picolGetCommand(i, argv[1]);
+	if (np) {
+		if (picolUnsetCommand(i, argv[1]) != PICKLE_OK) {
+			return PICKLE_ERROR;
+		}
+	}
 	return picolCommandAddProc(i, argv[1], argv[2], argv[3], 0);
 }
 

--- a/shell
+++ b/shell
@@ -588,7 +588,7 @@ fails {proc}
 fails {proc x}
 fails {proc x n}
 state {proc def {x} {}}
-fails {proc def {x} {}}
+test {} {proc def {x} {}}
 state {rename def ""}
 fails {variadic}
 state {variadic v1 n { return $n 0 }}


### PR DESCRIPTION
`proc` should replace a previous procedure with the same name. Tcl documentation, https://www.tcl.tk/man/tcl/TclCmd/proc.htm,  says:

> The proc command creates a new Tcl procedure named name, replacing any
> existing command or procedure there may have been by that name.


The current behavior forces you to manually remove any command with something like `catch {rename myproc} res` every time you re-source a script in the interpreter between edits. Consider the use case of doing the following for example:
1. Edit `myscript.tcl` in a text editor
2. `source myscript.tcl` in a pickle interpreter
3. GOTO 1
